### PR TITLE
Replace Google Analytics script with @next/third-parties package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
-    "@next/third-parties": "^1.0.0",
+    "@next/third-parties": "^14.2.3",
     "@tailwindcss/typography": "^0.5.4",
     "@types/mdx": "^2.0.13",
     "@types/node": "^20.10.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
+    "@next/third-parties": "^1.0.0",
     "@tailwindcss/typography": "^0.5.4",
     "@types/mdx": "^2.0.13",
     "@types/node": "^20.10.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@next/mdx':
     specifier: ^14.0.4
     version: 14.2.3(@mdx-js/loader@3.0.1)(@mdx-js/react@3.0.1)
+  '@next/third-parties':
+    specifier: ^14.2.3
+    version: 14.2.3(next@14.2.3)(react@18.3.1)
   '@tailwindcss/typography':
     specifier: ^0.5.4
     version: 0.5.13(tailwindcss@3.4.3)
@@ -631,6 +634,17 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@next/third-parties@14.2.3(next@14.2.3)(react@18.3.1):
+    resolution: {integrity: sha512-j4E2xBSsEZq4VX2pVm3LpGltSwCxETic6glJWfHyYQvpoMdplCAYrQKpF+E9Gg3jfsrfmRAIdTE11m+biBCx1Q==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0
+      react: ^18.2.0
+    dependencies:
+      next: 14.2.3(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      third-party-capital: 1.0.20
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4647,6 +4661,10 @@ packages:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
+    dev: false
+
+  /third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
     dev: false
 
   /to-regex-range@5.0.1:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from 'next'
-import { GoogleAnalytics } from '@next/third-parties'
+import { GoogleAnalytics } from '@next/third-parties/google'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
@@ -34,7 +34,7 @@ export default function RootLayout({
             <Layout>{children}</Layout>
           </div>
         </Providers>
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ''} />
       </body>
     </html>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import { type Metadata } from 'next'
-import Script from 'next/script'
-
+import { GoogleAnalytics } from '@next/third-parties'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
@@ -35,20 +34,7 @@ export default function RootLayout({
             <Layout>{children}</Layout>
           </div>
         </Providers>
-
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-          window.dataLayer = window.dataLayer || [];
-          
-          function gtag(){window.dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}');
-        `}
-        </Script>
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
       </body>
     </html>
   )


### PR DESCRIPTION
Related to #60

Replaces the manual Google Analytics script with the `@next/third-parties` internal package for optimized third-party script management.

- **Code Refactoring in `src/app/layout.tsx`:**
  - Removes the manual `<Script>` tags for Google Analytics.
  - Imports and utilizes the `GoogleAnalytics` component from `@next/third-parties`, passing the Google Analytics Measurement ID from environment variables.

- **Dependency Update in `package.json`:**
  - Adds `@next/third-parties` to the list of dependencies to support the new Google Analytics implementation.


> This PR was created using copilot-workspace - githubnext

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alphaolomi/alphaolomi.com/issues/60?shareId=0938672c-eaf0-4bd7-a88c-d1ba672e264c).